### PR TITLE
Optionally use readr's read_csv if it is available.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,9 @@ Description: The package provides convenient access to StatCan census data via C
 License: MIT
 Encoding: UTF-8
 LazyData: true
-Depends: dplyr (>= 0.7.2), readr (>= 1.1.1), httr (>= 1.2.1), jsonlite (>= 1.5), sf(>= 0.5-3), digest (>= 0.6.12)
+Depends: dplyr (>= 0.7.2),  httr (>= 1.2.1), jsonlite (>= 1.5), sf(>= 0.5-3), digest (>= 0.6.12)
 RoxygenNote: 6.0.1
 Suggests: knitr,
-    rmarkdown
+    rmarkdown,
+    readr
 VignetteBuilder: knitr

--- a/R/cancensus.R
+++ b/R/cancensus.R
@@ -46,11 +46,15 @@ cancensus.load <- function (dataset, level, regions, vectors=c(), geo=TRUE, form
       cancensus.handle_status_code(response,data_file)
     }
     # read the data file and transform to proper data types
-    dat <- read.csv(data_file,  na = c("x","F"), colClasses=c("GeoUID"="character","Type"="factor","Region Name"="factor"),stringsAsFactors=F, check.names = FALSE)
-#    dat <- read_csv(data_file, na = c("x","F")) %>%
-#      mutate(GeoUID = as.character(GeoUID),
-#             Type = as.factor(Type),
-#             `Region Name` = as.factor(`Region Name`))
+    if (requireNamespace("readr", quietly = TRUE)) {
+      # Use readr::read_csv if it's available.
+      dat <- readr::read_csv(data_file, na = c("x","F"))
+      dat$GeoUID <- as.character(dat$GeoUID)
+      dat$Type <- as.factor(dat$Type)
+      dat$`Region Name` <- as.factor(dat$`Region Name`)
+    } else {
+      dat <- read.csv(data_file,  na = c("x","F"), colClasses=c("GeoUID"="character","Type"="factor","Region Name"="factor"),stringsAsFactors=F, check.names = FALSE)
+    }
   } else if (!geo) {
     stop('Neither vectors nor geo data specified, nothing to do.')
   }


### PR DESCRIPTION
This makes use of `requireNamespace()` to check if the fast and reliable `readr` package is available, replacing the commented-out code left over from an older version. It also moves `readr` to the Suggests section, since its use is clearly optional. `readr::read_csv` should be available in all versions of the package, so there is no need to specify one.