### PR TITLE
Update cancensus.R

### DIFF
--- a/R/cancensus.R
+++ b/R/cancensus.R
@@ -186,11 +186,12 @@ list_datasets <- function() {
 #' variable name, and a column \code{label} describing it.
 #'
 #' @export
-cancensus.labels <-   if("census_labels" %in% names(attributes(dat))) {
-  attributes(dat)$census_labels
-} else {
-  warning("Data does not have variables to labels. No Census variables selected as vectors. See ?cancensus.load() for more information. ")
-}
+cancensus.labels <-  function(dat) {
+  if("census_labels" %in% names(attributes(dat))) {
+    attributes(dat)$census_labels
+  } else {
+    warning("Data does not have variables to labels. No Census variables selected as vectors. See ?cancensus.load() for more information. ")}
+  }
 
 
 #' Internal function to handle unfavourable http responses

--- a/R/cancensus.R
+++ b/R/cancensus.R
@@ -109,8 +109,8 @@ cancensus.load <- function (dataset, level, regions, vectors=c(), geo=TRUE, form
   if (length(vectors)>0) {
    census_labels <- names(result)[grep("^v_", names(result))]
    census_labels <- strsplit(census_labels, ": ")
-   census_labels <- as_data_frame(do.call(rbind, census_labels))
-   names(census_labels) <- c("Census Variable", "Detail")
+   census_labels <- dplyr::as_data_frame(do.call(rbind, census_labels))
+   names(census_labels) <- c("Vector", "Detail")
    attributes(result)$census_labels <- census_labels
    if(labels == "short") names(result@data) <- gsub(":.*","",names(result@data))
   }


### PR DESCRIPTION
* Update cancensus functions to store more information about Census variables as attributes that can be returned through an auxillary function called .labels(data)
* In conjunction, add parameter "labels" with option "short" to truncate long Census variable names to just the code. The associated labels can be accessed through the auxillary function.

Has been tested for data+spatial("sf"), data+spatial("sp)", non-spatial, and spatial-only. If you guys think this is useful, comment here and we can merge the PR. 