### PR TITLE
Cean up and clarify the geo format parameters

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,9 +12,11 @@ Description: The package provides convenient access to StatCan census data via C
 License: MIT
 Encoding: UTF-8
 LazyData: true
-Depends: dplyr (>= 0.7.2),  httr (>= 1.2.1), jsonlite (>= 1.5), sf(>= 0.5-3), digest (>= 0.6.12)
+Depends: dplyr (>= 0.7.2),  httr (>= 1.2.1), jsonlite (>= 1.5), digest (>= 0.6.12)
 RoxygenNote: 6.0.1
 Suggests: knitr,
     rmarkdown,
-    readr
+    readr,
+    rgdal,
+    sf
 VignetteBuilder: knitr

--- a/R/cancensus.R
+++ b/R/cancensus.R
@@ -15,7 +15,7 @@
 #' @param regions A json hash describing the geographic regions.
 #' @param vectors An R vector containing the CensusMapper variable names of the census variables to download. If no vectors are specified only geographic data will get downloaded.
 #' @param geo_format One of \code{"sf"} to return an \code{\link[sf]{sf}} object (the default; requires the \code{sf} package), \code{"sp"} to return a \code{\link[sp]{SpatialPolygonsDataFrame}} object (requires the \code{rgdal} package), or \code{NA} to append no geographical information to the returned data at all.
-#' @param labels Set to "detail" by default, but truncated Census variable names can be selected by setting labels = "short". Use cancensensus.labels() to return variable label information.
+#' @param labels Set to "detailed" by default, but truncated Census variable names can be selected by setting labels = "short". Use cancensensus.labels() to return variable label information.
 #' @param use_cache If set to TRUE (the default) data will be read from the local cache if available.
 #' @keywords canada census data api
 #' @export
@@ -121,32 +121,27 @@ cancensus.load <- function (dataset, level, regions, vectors=c(), geo_format = "
 }
 
 #' Convenience function to load only census data and no geographies.
-#' @param dataset A CensusMapper dataset identifier.
-#' @param level A geographic aggregation level for downloading data, e.g. CSD, CT, DA.
-#' @param regions A json hash describing the geographic regions.
-#' @param vectors An R vector containing the CensusMapper variable names of the census variables to download. If no vectors are specified only geographic data will get downloaded.
-#' @param geo If set to TRUE, the function will also return the geographic data.
-#' @param use_cache If set to TRUE (the default) data will be read from the local cache if available.
+#'
+#' @inheritParams cancensus.load
+#'
 #' @keywords canada census data api
 #' @export
 #' @examples
 #' census_data <- cancensus.load_data(dataset='CA16', regions='{"CMA":["59933"]}', vectors=c("v_CA16_408","v_CA16_409","v_CA16_410"), level='CSD')
-cancensus.load_data <- function (dataset, level, regions, vectors=c(), use_cache=TRUE, api_key=getOption("cancensus.api_key")) {
-  return(cancensus.load(dataset, level, regions, vectors, geo=FALSE, use_cache=use_cache, api_key=api_key))
+cancensus.load_data <- function (dataset, level, regions, vectors, labels = "detailed", use_cache=TRUE, api_key=getOption("cancensus.api_key")) {
+  return(cancensus.load(dataset, level, regions, vectors, geo_format=NA, labels=labels, use_cache=use_cache, api_key=api_key))
 }
 
 #' Convenience function to load only census geography without data.
-#' @param dataset A CensusMapper dataset identifier.
-#' @param level A geographic aggregation level for downloading data, e.g. CSD, CT, DA.
-#' @param regions A json hash describing the geographic regions.
-#' @param format Choose whether you want to use the sf or sp spatial format. Assumes sf as default but can be overwritten by selecting format = "sp".
-#' @param use_cache If set to TRUE (the default) data will be read from the local cache if available.
+#'
+#' @inheritParams cancensus.load
+#'
 #' @keywords canada census data api
 #' @export
 #' @examples
 #' census_data <- cancensus.load_geo(dataset='CA16', regions='{"CMA":["59933"]}', level='CSD')
-cancensus.load_geo <- function (dataset, level, regions, format, use_cache=TRUE, api_key=getOption("cancensus.api_key")) {
-  return(cancensus.load(dataset, level, regions, geo=TRUE, format = "sf", use_cache=use_cache, api_key=api_key))
+cancensus.load_geo <- function (dataset, level, regions, geo_format = "sf", labels = "detailed", use_cache=TRUE, api_key=getOption("cancensus.api_key")) {
+  return(cancensus.load(dataset, level, regions, vectors=c(), geo_format=geo_format, labels=labels, use_cache=use_cache, api_key=api_key))
 }
 
 #' Convenience function to set the api key for the current session.

--- a/R/cancensus.R
+++ b/R/cancensus.R
@@ -122,26 +122,28 @@ cancensus.load <- function (dataset, level, regions, vectors=c(), geo_format = "
 
 #' Convenience function to load only census data and no geographies.
 #'
+#' @param ... Further arguments passed on to \code{\link[cancensus]{cancensus.load}}.
 #' @inheritParams cancensus.load
 #'
 #' @keywords canada census data api
 #' @export
 #' @examples
 #' census_data <- cancensus.load_data(dataset='CA16', regions='{"CMA":["59933"]}', vectors=c("v_CA16_408","v_CA16_409","v_CA16_410"), level='CSD')
-cancensus.load_data <- function (dataset, level, regions, vectors, labels = "detailed", use_cache=TRUE, api_key=getOption("cancensus.api_key")) {
-  return(cancensus.load(dataset, level, regions, vectors, geo_format=NA, labels=labels, use_cache=use_cache, api_key=api_key))
+cancensus.load_data <- function (dataset, level, regions, vectors, ...) {
+  return(cancensus.load(dataset, level, regions, vectors, geo_format = NA, ...))
 }
 
 #' Convenience function to load only census geography without data.
 #'
+#' @param ... Further arguments passed on to \code{\link[cancensus]{cancensus.load}}.
 #' @inheritParams cancensus.load
 #'
 #' @keywords canada census data api
 #' @export
 #' @examples
 #' census_data <- cancensus.load_geo(dataset='CA16', regions='{"CMA":["59933"]}', level='CSD')
-cancensus.load_geo <- function (dataset, level, regions, geo_format = "sf", labels = "detailed", use_cache=TRUE, api_key=getOption("cancensus.api_key")) {
-  return(cancensus.load(dataset, level, regions, vectors=c(), geo_format=geo_format, labels=labels, use_cache=use_cache, api_key=api_key))
+cancensus.load_geo <- function (dataset, level, regions, geo_format = "sf", ...) {
+  return(cancensus.load(dataset, level, regions, vectors=c(), geo_format=geo_format, ...))
 }
 
 #' Convenience function to set the api key for the current session.

--- a/man/cancensus.load.Rd
+++ b/man/cancensus.load.Rd
@@ -4,8 +4,8 @@
 \alias{cancensus.load}
 \title{CensusMapper API access}
 \usage{
-cancensus.load(dataset, level, regions, vectors = c(), geo = TRUE,
-  format = "sf", use_cache = TRUE,
+cancensus.load(dataset, level, regions, vectors = c(), geo_format = "sf",
+  labels = "detailed", use_cache = TRUE,
   api_key = getOption("cancensus.api_key"))
 }
 \arguments{
@@ -17,9 +17,8 @@ cancensus.load(dataset, level, regions, vectors = c(), geo = TRUE,
 
 \item{vectors}{An R vector containing the CensusMapper variable names of the census variables to download. If no vectors are specified only geographic data will get downloaded.}
 
-\item{geo}{If set to TRUE, the function will also return the geographic data.}
+\item{geo_format}{One of \code{"sf"} to return an \code{\link[sf]{sf}} object (the default; requires the \code{sf} package), \code{"sp"} to return a \code{\link[sp]{SpatialPolygonsDataFrame}} object (requires the \code{rgdal} package), or \code{NA} to append no geographical information to the returned data at all.}
 
-\item{format}{Choose whether you want to use the sf or sp spatial format. Using sf will return a dataframe with a field for sf geometry, while using sp will return a SpatialPolygonsDataFrame object. Assumes sf as default but can be overwritten by selecting format = "sp".}
 
 \item{use_cache}{If set to TRUE (the default) data will be read from the local cache if available.}
 }

--- a/man/cancensus.load.Rd
+++ b/man/cancensus.load.Rd
@@ -19,6 +19,7 @@ cancensus.load(dataset, level, regions, vectors = c(), geo_format = "sf",
 
 \item{geo_format}{One of \code{"sf"} to return an \code{\link[sf]{sf}} object (the default; requires the \code{sf} package), \code{"sp"} to return a \code{\link[sp]{SpatialPolygonsDataFrame}} object (requires the \code{rgdal} package), or \code{NA} to append no geographical information to the returned data at all.}
 
+\item{labels}{Set to "detailed" by default, but truncated Census variable names can be selected by setting labels = "short". Use cancensensus.labels() to return variable label information.}
 
 \item{use_cache}{If set to TRUE (the default) data will be read from the local cache if available.}
 }
@@ -36,6 +37,9 @@ sys.setenv(CM_API_KEY='<your API key>')
 }
 \examples{
 census_data <- cancensus.load(dataset='CA16', regions='{"CMA":["59933"]}', vectors=c("v_CA16_408","v_CA16_409","v_CA16_410"), level='CSD', geo=TRUE)
+census_data <- cancensus.load(dataset='CA16', regions='{"CMA":["59933"]}', vectors=c("v_CA16_408","v_CA16_409","v_CA16_410"), level='CSD', geo=TRUE, labels="short")
+# Get details for truncated variables
+cancensus.labels(census_data)
 }
 \keyword{api}
 \keyword{canada}

--- a/man/cancensus.load_data.Rd
+++ b/man/cancensus.load_data.Rd
@@ -4,7 +4,7 @@
 \alias{cancensus.load_data}
 \title{Convenience function to load only census data and no geographies.}
 \usage{
-cancensus.load_data(dataset, level, regions, vectors = c(),
+cancensus.load_data(dataset, level, regions, vectors, labels = "detailed",
   use_cache = TRUE, api_key = getOption("cancensus.api_key"))
 }
 \arguments{
@@ -16,9 +16,9 @@ cancensus.load_data(dataset, level, regions, vectors = c(),
 
 \item{vectors}{An R vector containing the CensusMapper variable names of the census variables to download. If no vectors are specified only geographic data will get downloaded.}
 
-\item{use_cache}{If set to TRUE (the default) data will be read from the local cache if available.}
+\item{labels}{Set to "detailed" by default, but truncated Census variable names can be selected by setting labels = "short". Use cancensensus.labels() to return variable label information.}
 
-\item{geo}{If set to TRUE, the function will also return the geographic data.}
+\item{use_cache}{If set to TRUE (the default) data will be read from the local cache if available.}
 }
 \description{
 Convenience function to load only census data and no geographies.

--- a/man/cancensus.load_data.Rd
+++ b/man/cancensus.load_data.Rd
@@ -4,8 +4,7 @@
 \alias{cancensus.load_data}
 \title{Convenience function to load only census data and no geographies.}
 \usage{
-cancensus.load_data(dataset, level, regions, vectors, labels = "detailed",
-  use_cache = TRUE, api_key = getOption("cancensus.api_key"))
+cancensus.load_data(dataset, level, regions, vectors, ...)
 }
 \arguments{
 \item{dataset}{A CensusMapper dataset identifier.}
@@ -16,9 +15,7 @@ cancensus.load_data(dataset, level, regions, vectors, labels = "detailed",
 
 \item{vectors}{An R vector containing the CensusMapper variable names of the census variables to download. If no vectors are specified only geographic data will get downloaded.}
 
-\item{labels}{Set to "detailed" by default, but truncated Census variable names can be selected by setting labels = "short". Use cancensensus.labels() to return variable label information.}
-
-\item{use_cache}{If set to TRUE (the default) data will be read from the local cache if available.}
+\item{...}{Further arguments passed on to \code{\link[cancensus]{cancensus.load}}.}
 }
 \description{
 Convenience function to load only census data and no geographies.

--- a/man/cancensus.load_geo.Rd
+++ b/man/cancensus.load_geo.Rd
@@ -4,9 +4,7 @@
 \alias{cancensus.load_geo}
 \title{Convenience function to load only census geography without data.}
 \usage{
-cancensus.load_geo(dataset, level, regions, geo_format = "sf",
-  labels = "detailed", use_cache = TRUE,
-  api_key = getOption("cancensus.api_key"))
+cancensus.load_geo(dataset, level, regions, geo_format = "sf", ...)
 }
 \arguments{
 \item{dataset}{A CensusMapper dataset identifier.}
@@ -17,9 +15,7 @@ cancensus.load_geo(dataset, level, regions, geo_format = "sf",
 
 \item{geo_format}{One of \code{"sf"} to return an \code{\link[sf]{sf}} object (the default; requires the \code{sf} package), \code{"sp"} to return a \code{\link[sp]{SpatialPolygonsDataFrame}} object (requires the \code{rgdal} package), or \code{NA} to append no geographical information to the returned data at all.}
 
-\item{labels}{Set to "detailed" by default, but truncated Census variable names can be selected by setting labels = "short". Use cancensensus.labels() to return variable label information.}
-
-\item{use_cache}{If set to TRUE (the default) data will be read from the local cache if available.}
+\item{...}{Further arguments passed on to \code{\link[cancensus]{cancensus.load}}.}
 }
 \description{
 Convenience function to load only census geography without data.

--- a/man/cancensus.load_geo.Rd
+++ b/man/cancensus.load_geo.Rd
@@ -4,7 +4,8 @@
 \alias{cancensus.load_geo}
 \title{Convenience function to load only census geography without data.}
 \usage{
-cancensus.load_geo(dataset, level, regions, format, use_cache = TRUE,
+cancensus.load_geo(dataset, level, regions, geo_format = "sf",
+  labels = "detailed", use_cache = TRUE,
   api_key = getOption("cancensus.api_key"))
 }
 \arguments{
@@ -14,7 +15,9 @@ cancensus.load_geo(dataset, level, regions, format, use_cache = TRUE,
 
 \item{regions}{A json hash describing the geographic regions.}
 
-\item{format}{Choose whether you want to use the sf or sp spatial format. Assumes sf as default but can be overwritten by selecting format = "sp".}
+\item{geo_format}{One of \code{"sf"} to return an \code{\link[sf]{sf}} object (the default; requires the \code{sf} package), \code{"sp"} to return a \code{\link[sp]{SpatialPolygonsDataFrame}} object (requires the \code{rgdal} package), or \code{NA} to append no geographical information to the returned data at all.}
+
+\item{labels}{Set to "detailed" by default, but truncated Census variable names can be selected by setting labels = "short". Use cancensensus.labels() to return variable label information.}
 
 \item{use_cache}{If set to TRUE (the default) data will be read from the local cache if available.}
 }


### PR DESCRIPTION
This PR reflects the need to move both `sf` and `rgdal` to the Suggests section of the `DESCRIPTION` file, and ensure that one of them is present when requesting geo data, but that users can opt in to either the `sf` or `sp` paradigms without installing the packages needed for the other. This also cleans up later code, and removes the call to `install.package()`, since there's no need for it now.

I've also taken the liberty of amalgamating the `format` and `geo` options into a single paramter. Users can pass `NA` to avoid returning spatial data. Since this is a breaking change, I'll need to check existing snippets and vignettes to accomodate the change.

(The commits also contain these descriptions.)