### PR TITLE
Change the regions parameter to a named list

### DIFF
--- a/R/cancensus.R
+++ b/R/cancensus.R
@@ -30,10 +30,14 @@ cancensus.load <- function (dataset, level, regions, vectors=c(), geo_format = "
   result <- NULL
 
   # Turn the region list into a valid JSON dictionary.
-  if (is.null(names(regions)) || !all(names(regions) %in% VALID_LEVELS)) {
+  if (is.character(regions)) {
+    warning(paste("passing `regions` as a character vector is depreciated, and",
+                  "will be removed in future versions"))
+  } else if (is.null(names(regions)) || !all(names(regions) %in% VALID_LEVELS)) {
     stop("regions must be composed of valid census aggregation levels.")
+  } else {
+    regions <- jsonlite::toJSON(regions)
   }
-  regions <- jsonlite::toJSON(regions)
 
   # Check if the aggregation level is valid.
   if (!level %in% VALID_LEVELS) {

--- a/R/cancensus.R
+++ b/R/cancensus.R
@@ -11,7 +11,7 @@
 #' sys.setenv(CM_API_KEY='<your API key>')
 #'
 #' @param dataset A CensusMapper dataset identifier.
-#' @param level A geographic aggregation level for downloading data, e.g. CSD, CT, DA.
+#' @param level The census aggregation level to retrieve. One of \code{"PR"}, \code{"CMA"}, \code{"CD"}, \code{"CSD"}, \code{"CT"} or \code{"DA"}.
 #' @param regions A named list of census regions to retrieve. Names must be valid census aggregation levels.
 #' @param vectors An R vector containing the CensusMapper variable names of the census variables to download. If no vectors are specified only geographic data will get downloaded.
 #' @param geo_format One of \code{"sf"} to return an \code{\link[sf]{sf}} object (the default; requires the \code{sf} package), \code{"sp"} to return a \code{\link[sp]{SpatialPolygonsDataFrame}} object (requires the \code{rgdal} package), or \code{NA} to append no geographical information to the returned data at all.
@@ -34,6 +34,11 @@ cancensus.load <- function (dataset, level, regions, vectors=c(), geo_format = "
     stop("regions must be composed of valid census aggregation levels.")
   }
   regions <- jsonlite::toJSON(regions)
+
+  # Check if the aggregation level is valid.
+  if (!level %in% VALID_LEVELS) {
+    stop("the `level` parameter must be one of 'PR', 'CMA', 'CD', 'CSD', 'CT', or 'DA'")
+  }
 
   # Check that we can read the requested geo format.
   if (is.na(geo_format)) { # This is ok.

--- a/man/cancensus.load.Rd
+++ b/man/cancensus.load.Rd
@@ -11,7 +11,7 @@ cancensus.load(dataset, level, regions, vectors = c(), geo_format = "sf",
 \arguments{
 \item{dataset}{A CensusMapper dataset identifier.}
 
-\item{level}{A geographic aggregation level for downloading data, e.g. CSD, CT, DA.}
+\item{level}{The census aggregation level to retrieve. One of \code{"PR"}, \code{"CMA"}, \code{"CD"}, \code{"CSD"}, \code{"CT"} or \code{"DA"}.}
 
 \item{regions}{A named list of census regions to retrieve. Names must be valid census aggregation levels.}
 

--- a/man/cancensus.load.Rd
+++ b/man/cancensus.load.Rd
@@ -13,7 +13,7 @@ cancensus.load(dataset, level, regions, vectors = c(), geo_format = "sf",
 
 \item{level}{A geographic aggregation level for downloading data, e.g. CSD, CT, DA.}
 
-\item{regions}{A json hash describing the geographic regions.}
+\item{regions}{A named list of census regions to retrieve. Names must be valid census aggregation levels.}
 
 \item{vectors}{An R vector containing the CensusMapper variable names of the census variables to download. If no vectors are specified only geographic data will get downloaded.}
 
@@ -36,8 +36,8 @@ or as environment variable
 sys.setenv(CM_API_KEY='<your API key>')
 }
 \examples{
-census_data <- cancensus.load(dataset='CA16', regions='{"CMA":["59933"]}', vectors=c("v_CA16_408","v_CA16_409","v_CA16_410"), level='CSD', geo=TRUE)
-census_data <- cancensus.load(dataset='CA16', regions='{"CMA":["59933"]}', vectors=c("v_CA16_408","v_CA16_409","v_CA16_410"), level='CSD', geo=TRUE, labels="short")
+census_data <- cancensus.load(dataset='CA16', regions=list(CMA="59933"), vectors=c("v_CA16_408","v_CA16_409","v_CA16_410"), level='CSD', geo=TRUE)
+census_data <- cancensus.load(dataset='CA16', regions=list(CMA="59933"), vectors=c("v_CA16_408","v_CA16_409","v_CA16_410"), level='CSD', geo=TRUE, labels="short")
 # Get details for truncated variables
 cancensus.labels(census_data)
 }

--- a/man/cancensus.load_data.Rd
+++ b/man/cancensus.load_data.Rd
@@ -11,7 +11,7 @@ cancensus.load_data(dataset, level, regions, vectors, ...)
 
 \item{level}{A geographic aggregation level for downloading data, e.g. CSD, CT, DA.}
 
-\item{regions}{A json hash describing the geographic regions.}
+\item{regions}{A named list of census regions to retrieve. Names must be valid census aggregation levels.}
 
 \item{vectors}{An R vector containing the CensusMapper variable names of the census variables to download. If no vectors are specified only geographic data will get downloaded.}
 

--- a/man/cancensus.load_data.Rd
+++ b/man/cancensus.load_data.Rd
@@ -9,7 +9,7 @@ cancensus.load_data(dataset, level, regions, vectors, ...)
 \arguments{
 \item{dataset}{A CensusMapper dataset identifier.}
 
-\item{level}{A geographic aggregation level for downloading data, e.g. CSD, CT, DA.}
+\item{level}{The census aggregation level to retrieve. One of \code{"PR"}, \code{"CMA"}, \code{"CD"}, \code{"CSD"}, \code{"CT"} or \code{"DA"}.}
 
 \item{regions}{A named list of census regions to retrieve. Names must be valid census aggregation levels.}
 

--- a/man/cancensus.load_geo.Rd
+++ b/man/cancensus.load_geo.Rd
@@ -11,7 +11,7 @@ cancensus.load_geo(dataset, level, regions, geo_format = "sf", ...)
 
 \item{level}{A geographic aggregation level for downloading data, e.g. CSD, CT, DA.}
 
-\item{regions}{A json hash describing the geographic regions.}
+\item{regions}{A named list of census regions to retrieve. Names must be valid census aggregation levels.}
 
 \item{geo_format}{One of \code{"sf"} to return an \code{\link[sf]{sf}} object (the default; requires the \code{sf} package), \code{"sp"} to return a \code{\link[sp]{SpatialPolygonsDataFrame}} object (requires the \code{rgdal} package), or \code{NA} to append no geographical information to the returned data at all.}
 

--- a/man/cancensus.load_geo.Rd
+++ b/man/cancensus.load_geo.Rd
@@ -9,7 +9,7 @@ cancensus.load_geo(dataset, level, regions, geo_format = "sf", ...)
 \arguments{
 \item{dataset}{A CensusMapper dataset identifier.}
 
-\item{level}{A geographic aggregation level for downloading data, e.g. CSD, CT, DA.}
+\item{level}{The census aggregation level to retrieve. One of \code{"PR"}, \code{"CMA"}, \code{"CD"}, \code{"CSD"}, \code{"CT"} or \code{"DA"}.}
 
 \item{regions}{A named list of census regions to retrieve. Names must be valid census aggregation levels.}
 


### PR DESCRIPTION
As discussed in #27. This is a quick implementation that does validation on the client side, and recycles this validation for the `levels` parameter in the process.

Documentation and examples will need to be updated, since this is a breaking API change.