### PR TITLE
Notify the user when reading data from the local cache

### DIFF
--- a/R/cancensus.R
+++ b/R/cancensus.R
@@ -55,6 +55,8 @@ cancensus.load <- function (dataset, level, regions, vectors=c(), geo_format = "
       response <- httr::GET(url, httr::write_disk(data_file, overwrite = TRUE),
                             httr::progress())
       cancensus.handle_status_code(response,data_file)
+    } else {
+      message("Reading vectors data from local cache.")
     }
     # read the data file and transform to proper data types
     if (requireNamespace("readr", quietly = TRUE)) {
@@ -82,6 +84,8 @@ cancensus.load <- function (dataset, level, regions, vectors=c(), geo_format = "
       response <- httr::GET(url, httr::write_disk(geo_file, overwrite = TRUE),
                             httr::progress())
       cancensus.handle_status_code(response,geo_file)
+    } else {
+      message("Reading geo data from local cache.")
     }
     # read the geo file and transform to proper data types
     result <- if (geo_format == "sf") {


### PR DESCRIPTION
This is a simple quality-of-life addition. If the user has `httr.show_progress` disabled, there's no visual indication that we're reading from the network or the local data cache. This PR adds a message to resolve this.