### PR TITLE
add the 'add' column to the select and cache result of vector list

### DIFF
--- a/R/cancensus.R
+++ b/R/cancensus.R
@@ -218,7 +218,7 @@ cancensus.load <- function (dataset, level, regions, vectors=c(), geo_format = "
    names(census_labels) <- c("Vector", "Detail")
    attributes(result)$census_labels <- census_labels
    if(labels == "short") {
-     if (geo_format=="sp") {names(result@data) <- gsub(":.*","",names(result@data))}
+     if (!is.na(geo_format) && geo_format=="sp") {names(result@data) <- gsub(":.*","",names(result@data))}
      else {names(result) <- gsub(":.*","",names(result))}
    }
   }
@@ -313,6 +313,8 @@ cancensus.list_vectors <- function(dataset, use_cache=TRUE) {
     response <- httr::GET(url, httr::write_disk(vector_file, overwrite = TRUE),
                           httr::progress())
     cancensus.handle_status_code(response,vector_file)
+  } else {
+    message("Reading vector information from local cache.")
   }
   if  (!requireNamespace("readr", quietly = TRUE)) {
     result <- utils::read.csv(vector_file, encoding = "UTF-8",stringsAsFactors = FALSE)

--- a/man/cancensus.list_vectors.Rd
+++ b/man/cancensus.list_vectors.Rd
@@ -4,11 +4,13 @@
 \alias{cancensus.list_vectors}
 \title{Query the CensusMapper API for available vectors for a given dataset.}
 \usage{
-cancensus.list_vectors(dataset)
+cancensus.list_vectors(dataset, use_cache = TRUE)
 }
 \arguments{
 \item{dataset}{The dataset to query for available vectors, e.g.
 \code{"CA16"}.}
+
+\item{use_cache}{If set to TRUE (the default) data will be read from the local cache if available.}
 }
 \description{
 Query the CensusMapper API for available vectors for a given dataset.


### PR DESCRIPTION
Quickfix to add the 'add' column into the select and implement basic client side caching of the vector list.