### PR TITLE
add cache directory to repo

### DIFF
--- a/inst/cache/.gitignore
+++ b/inst/cache/.gitignore
@@ -1,0 +1,8 @@
+# .gitignore sample 
+###################
+
+# ignore all files in this dir...
+*
+
+# ... except for this one.
+!.gitignore


### PR DESCRIPTION
This *should* deal with the issue that cache directory was missing from installation. Not sure what the best way to test this is, ideally use a clean install via `devtools` and check that
```
cache_dir <- system.file("cache/", package = "cancensus",mustWork = TRUE)
```
goes through without complaining.