### PR TITLE
Change default geo format behaviour

### DIFF
--- a/R/cancensus.R
+++ b/R/cancensus.R
@@ -1,10 +1,10 @@
 #' Access to Canadian census data through the CensusMapper API
 #'
-#' These function allow convenient access to Canadian census data and boundary
+#' This function allows convenient access to Canadian census data and boundary
 #' files through the CensusMapper API. An API key is required to retrieve data.
 #'
-#' \code{get_census_data} and \code{get_census_geometry} are convenience
-#' functions that retrive only data or boundary information, respectively.
+#' \code{get_census_geometry} is a convenience function
+#' that retrives only Census geography boundaries.
 #'
 #' For help selecting regions and vectors, see \code{\link{list_census_regions}}
 #' and \code{\link{list_census_vectors}}, or check out the interactive selection
@@ -14,14 +14,14 @@
 #' @param level The census aggregation level to retrieve. One of \code{"Regions"}, \code{"PR"}, \code{"CMA"}, \code{"CD"}, \code{"CSD"}, \code{"CT"} or \code{"DA"}.
 #' @param regions A named list of census regions to retrieve. Names must be valid census aggregation levels.
 #' @param vectors An R vector containing the CensusMapper variable names of the census variables to download. If no vectors are specified only geographic data will get downloaded.
-#' @param geo_format One of \code{"sf"} to return an \code{\link[sf]{sf}} object (the default; requires the \code{sf} package), \code{"sp"} to return a \code{\link[sp]{SpatialPolygonsDataFrame}} object (requires the \code{rgdal} package), or \code{NA} to append no geographical information to the returned data at all.
+#' @param geo_format By default is set to \code{NA} and appends no geographic information. To include geographic information with census data, specify one of either \code{"sf"} to return an \code{\link[sf]{sf}} object (requires the \code{sf} package) or \code{"sp"} to return a \code{\link[sp]{SpatialPolygonsDataFrame}} object (requires the \code{rgdal} package).
 #' @param labels Set to "detailed" by default, but truncated Census variable names can be selected by setting labels = "short". Use cancensensus.labels() to return variable label information.
 #' @param use_cache If set to TRUE (the default) data will be read from the local cache if available.
 #' @param api_key An API key for the CensusMapper API. Defaults to \code{options()} and then the \code{CM_API_KEY} environment variable.
 #'
 #' @keywords canada census data api
 #'
-#' @source Census data and boundary geometries are reproduced and distributed on
+#' @source Census data and boundary geographies are reproduced and distributed on
 #' an "as is" basis with the permission of Statistics Canada (Statistics Canada
 #' 2006; 2011; 2016).
 #'
@@ -29,7 +29,18 @@
 #'
 #' @examples
 #' # Query the API for data on dwellings in Vancouver, at the census subdivision
-#' # level, and return the associated boundary files in `sf` format:
+#' # level:
+#' census_data <- get_census(dataset='CA16', regions=list(CMA="59933"),
+#'                           vectors=c("v_CA16_408","v_CA16_409","v_CA16_410"),
+#'                           level='CSD')
+#'
+#' # Query the API for data on dwellings in Vancouver, at the census subdivision
+#' # level, and return the associated geography files in \code{sf} format:
+#' census_data <- get_census(dataset='CA16', regions=list(CMA="59933"),
+#'                           vectors=c("v_CA16_408","v_CA16_409","v_CA16_410"),
+#'                           level='CSD', geo_format = "sf")
+#' 
+#' # Make the same query, but return geography in \code{sp} format:
 #' census_data <- get_census(dataset='CA16', regions=list(CMA="59933"),
 #'                           vectors=c("v_CA16_408","v_CA16_409","v_CA16_410"),
 #'                           level='CSD', geo_format = "sf")
@@ -42,7 +53,7 @@
 #' # Get details for truncated vectors:
 #' census_vectors(census_data)
 #'
-get_census <- function (dataset, level, regions, vectors=c(), geo_format = "sf", labels = "detailed", use_cache=TRUE, api_key=getOption("cancensus.api_key")) {
+get_census <- function (dataset, level, regions, vectors=c(), geo_format = NA, labels = "detailed", use_cache=TRUE, api_key=getOption("cancensus.api_key")) {
   api_key <- if (is.null(api_key) && nchar(Sys.getenv("CM_API_KEY")) > 1) { Sys.getenv("CM_API_KEY") } else { api_key }
   have_api_key <- !is.null(api_key)
   result <- NULL
@@ -175,23 +186,6 @@ get_census <- function (dataset, level, regions, vectors=c(), geo_format = "sf",
    }
   }
   return(result)
-}
-
-#' @param ... Further arguments passed on to
-#'   \code{\link[cancensus]{get_census}}.
-#'
-#' @rdname get_census
-#' @export
-#'
-#' @examples
-#' # Query the API for dwelling data in Vancouver at the census subdivision
-#' # level, but not the associated boundary geometry.
-#' vc_dwellings <- get_census_data(dataset='CA16', regions=list(CMA:"59933"),
-#'                                 vectors=c("v_CA16_408","v_CA16_409",
-#'                                           "v_CA16_410"), level='CSD')
-#'
-get_census_data <- function (dataset, level, regions, vectors, ...) {
-  return(get_census(dataset, level, regions, vectors, geo_format = NA, ...))
 }
 
 #' @rdname get_census
@@ -579,7 +573,7 @@ search_census_regions <- function(searchterm, dataset, level=NA, ...) {
 #'   dplyr::sample_n(20) %>%
 #'   as_census_region_list()
 #'
-#' occupied <- get_census_data("CA16", regions = regions,
+#' occupied <- get_census("CA16", regions = regions,
 #'                             vectors = c("v_CA16_408"),
 #'                             level = "Regions")
 #'

--- a/README.md
+++ b/README.md
@@ -24,10 +24,43 @@ library(cancensus)
 
 ## Picking regions and variables
 
-Census data contains thousands of different geographic regions as well as thousands of unique variables. An interactive tool is available at [CensusMapper API call generator](https://censusmapper.ca/api) to select regions and variables and generate code for the API call, for example:
+Census data contains thousands of different geographic regions as well as thousands of unique variables. There are several useful functions within **cancensus** to simplify accessing Census metadata, locating regions, and identifying variables.
 
 ```
+# To view available Census datasets
+list_census_datasets()
+
+# To view available named regions at different levels of Census hierarchy for the 2016 Census (for example)
+list_census_regions("CA16")
+
+# To view available Census variables for the 2016 Census
+list_census_vectors("CA16")
+```
+
+As the number of Census regions and variables is significant, and Census naming patterns are not always the most intuitive, there are a few functions to help users narrow down the data to what they need. These functions will try to catch mispelled search terms and prompt the user with correctly-spelled alternatives.
+
+```
+# To search for regions containing a specific term (e.g. "Victoria") in them in the 2016 Census
+search_census_regions("Victoria","CA16")
+
+# To search for variables whose description or label contains a specific term (e.g. "Ojibwe")
+search_census_vectors("Ojibwe","CA16")
+```
+
+There is also an interactive tool that is available at [CensusMapper API call generator](https://censusmapper.ca/api) to visually select regions and variables and generate code for the API call.
+
+## Getting the data
+
+**cancensus** can return census data with or without associated Census geographical information that can be used for mapping and GIS. By default, **cancensus** returns tidy tabular data only, but has options to return spatial data objects in either [**sf**](https://github.com/r-spatial/sf) or [**sp**](https://cran.r-project.org/web/packages/sp/sp.pdf) formats. 
+```
+# Return data only
+census_data <- get_census(dataset='CA16', regions=list(CMA="59933"), vectors=c("v_CA16_408","v_CA16_409","v_CA16_410"), level='CSD')
+
+# Return an sf-class data frame
 census_data <- get_census(dataset='CA16', regions=list(CMA="59933"), vectors=c("v_CA16_408","v_CA16_409","v_CA16_410"), level='CSD', geo_format = "sf")
+
+# Return a SpatialPolygonsDataFrame
+census_data <- get_census(dataset='CA16', regions=list(CMA="59933"), vectors=c("v_CA16_408","v_CA16_409","v_CA16_410"), level='CSD', geo_format = "sp")
 
 # Additional options can viewed in documentation by entering ?get_census() in your R console
 ```
@@ -57,7 +90,6 @@ ggplot(census_data) +
 ```
 ## To-do
 
-* Provide more information about available datasets, Census variables, and geography directly through the **cancensus** package.
 * Expand vignettes and provide additional examples
 * Submit to CRAN
 


### PR DESCRIPTION
As in discussed in #73 
* Set default level for geography to be NA with options to explicitly add census geography in sf or sp form
* Remove `get_census_data()` functionality as it's duplicated by `get_census()`
* Remove mentions of `get_census_data()`
