### PR TITLE
parse parent region geo_uids

### DIFF
--- a/R/cancensus.R
+++ b/R/cancensus.R
@@ -477,6 +477,12 @@ search_census_vectors <- function(searchterm, dataset, type=NA, ...) {
 #'
 #'   \item{\code{municipal_status}}{Additional identifiers to distinguish the
 #'     municipal status of census subdivisions.}
+#'
+#'   \item{\code{CMA_UID}}{The identifier for the Census Metropolitan Area the region is in (if any).}
+#'
+#'   \item{\code{CD_UID}}{The identifier for the Census District the region is in (if any).}
+#'
+#'   \item{\code{PR_UID}}{The identifier for the Province the region is in (if uniqe).}
 #' }
 #'
 #' @export
@@ -496,7 +502,7 @@ list_census_regions <- function(dataset, use_cache = FALSE, quiet = FALSE) {
       readr::read_csv(content)
     }
     result <- dplyr::select(result, region = geo_uid, name, level = type,
-                            pop = population, municipal_status = flag)
+                            pop = population, municipal_status = flag, CMA_UID,CD_UID,PR_UID)
     attr(result, "last_updated") <- Sys.time()
     save(result, file = cache_file)
     result

--- a/man/list_census_regions.Rd
+++ b/man/list_census_regions.Rd
@@ -30,6 +30,12 @@ Returns a data frame with the following columns:
 
   \item{\code{municipal_status}}{Additional identifiers to distinguish the
     municipal status of census subdivisions.}
+
+  \item{\code{CMA_UID}}{The identifier for the Census Metropolitan Area the region is in (if any).}
+
+  \item{\code{CD_UID}}{The identifier for the Census District the region is in (if any).}
+
+  \item{\code{PR_UID}}{The identifier for the Province the region is in (if uniqe).}
 }
 }
 \description{


### PR DESCRIPTION
I added the "parent" regions to the place name data API, this pull request makes sure they are available in `cancensus` in the `list_regions` call.

This enables more pinpointed region searches, for example "give me the 4 largest municipalities in Metro Vancouver" would be
```
cma_id <- list_census_regions('CA16') %>% filter(level=='CMA', name=='Vancouver') %>% pull("region")
csds <- list_census_regions('CA16', use_cache=TRUE) %>% 
  filter(level=='CSD', CMA_UID==cma_id) %>%
  top_n(4,pop)
```