### PR TITLE
rename census_vectors function to label_vectors

### DIFF
--- a/R/cancensus.R
+++ b/R/cancensus.R
@@ -15,7 +15,7 @@
 #' @param regions A named list of census regions to retrieve. Names must be valid census aggregation levels.
 #' @param vectors An R vector containing the CensusMapper variable names of the census variables to download. If no vectors are specified only geographic data will get downloaded.
 #' @param geo_format By default is set to \code{NA} and appends no geographic information. To include geographic information with census data, specify one of either \code{"sf"} to return an \code{\link[sf]{sf}} object (requires the \code{sf} package) or \code{"sp"} to return a \code{\link[sp]{SpatialPolygonsDataFrame}} object (requires the \code{rgdal} package).
-#' @param labels Set to "detailed" by default, but truncated Census variable names can be selected by setting labels = "short". Use \code{census_vectors(...)} to return variable label information in detail.
+#' @param labels Set to "detailed" by default, but truncated Census variable names can be selected by setting labels = "short". Use \code{label_vectors(...)} to return variable label information in detail.
 #' @param use_cache If set to TRUE (the default) data will be read from the local cache if available.
 #' @param quiet When TRUE, suppress messages and warnings.
 #' @param api_key An API key for the CensusMapper API. Defaults to \code{options()} and then the \code{CM_API_KEY} environment variable.
@@ -615,7 +615,7 @@ as_census_region_list <- function(tbl) {
 #' variable name, and a column \code{label} describing it.
 #'
 #' @export
-census_vectors <-  function(x) {
+label_vectors <-  function(x) {
   if("census_vectors" %in% names(attributes(x))) {
     attr(x, "census_vectors")
   } else {


### PR DESCRIPTION
Personally, I find the name of this function, `census_vectors` to be confusing with regards to what it actually does: display detailed labels for truncated variable names. This is particularly apparent when you list the function along side other auxiliary functions like `list_census_vectors`, `search_census_vectors`, `parent_census_vectors`, etc., where there's a clear semantic connection between the name and the function. I would argue that the current name doesn't fit, and should be renamed to something else. I went with `label_vectors`, but it doesn't have be that. Could also see something like `detail_vectors` or `vector_detail` or `info_vectors` or `vector_info` working here. 