### PR TITLE
Fix an error when empty vector list is passed to child_census_vectors.

### DIFF
--- a/R/cancensus.R
+++ b/R/cancensus.R
@@ -383,23 +383,25 @@ child_census_vectors <- function(vector_list, leaves_only=FALSE){
   base_list <- vector_list
   dataset <- attr(base_list,'dataset')
   n=0
-  vector_list <-
-    list_census_vectors(dataset, use_cache = TRUE, quiet = TRUE) %>%
-    dplyr::filter(parent_vector %in% base_list$vector) %>%
-    dplyr::distinct(vector, .keep_all = TRUE)
-  while (n!=nrow(vector_list)) {
-    n=nrow(vector_list)
-    new_list <- list_census_vectors(dataset, use_cache = TRUE, quiet = TRUE) %>%
-      dplyr::filter(parent_vector %in% vector_list$vector)
-    vector_list <- vector_list %>% rbind(new_list) %>%
+  if (!is.null(dataset)) {
+    vector_list <-
+      list_census_vectors(dataset, use_cache = TRUE, quiet = TRUE) %>%
+      dplyr::filter(parent_vector %in% base_list$vector) %>%
       dplyr::distinct(vector, .keep_all = TRUE)
+    while (n!=nrow(vector_list)) {
+      n=nrow(vector_list)
+      new_list <- list_census_vectors(dataset, use_cache = TRUE, quiet = TRUE) %>%
+        dplyr::filter(parent_vector %in% vector_list$vector)
+      vector_list <- vector_list %>% rbind(new_list) %>%
+        dplyr::distinct(vector, .keep_all = TRUE)
+    }
+    # only keep leaves if leaves_only==TRUE
+    if (leaves_only) {
+      vector_list <- vector_list %>%
+        dplyr::filter(!(vector %in% list_census_vectors(dataset, use_cache = TRUE, quiet = TRUE)$parent_vector))
+    }
+    attr(vector_list, "dataset") <- dataset
   }
-  # only keep leaves if leaves_only==TRUE
-  if (leaves_only) {
-    vector_list <- vector_list %>%
-      dplyr::filter(!(vector %in% list_census_vectors(dataset, use_cache = TRUE, quiet = TRUE)$parent_vector))
-  }
-  attr(vector_list, "dataset") <- dataset
   return(vector_list)
 }
 


### PR DESCRIPTION
When an empty vector list parameter is passed to `child_census_vectors` function, it raises an error because `dataset` attribute is `NULL` and a call to `list_census_vectors` fails because of invalid parameter.

The following example illustrates this:
```
      search_census_vectors(
        "no results for me",
        "CA16,
        type = "Total",
        use_cache = TRUE
      ) %>%
      child_census_vectors(leaves_only = FALSE)
```
While in the example above this can be worked around by checking if number of rows returned by `search_census_vectors` is greater than 0, it would break the piping.
This pull request fixes this issue by making sure `child_census_vectors` returns an empty list, which is valid because an empty vectors list doesn't have any child nodes.