### PR TITLE
Make list_census_vectors quiet by default

### DIFF
--- a/R/cancensus.R
+++ b/R/cancensus.R
@@ -270,12 +270,12 @@ list_census_datasets <- function(use_cache = FALSE, quiet = FALSE) {
 #' @param use_cache If set to TRUE, data will be read from a local cache, if
 #'   available. If set to FALSE (the default), query the API for the data, and
 #'   refresh the local cache with the result.
-#' @param quiet When TRUE, suppress messages and warnings.
+#' @param quiet When FALSE, showss messages and warnings. Set to TRUE by default.
 #'
 #' @export
 #'
 #' @importFrom dplyr %>%
-list_census_vectors <- function(dataset, use_cache = FALSE, quiet = FALSE) {
+list_census_vectors <- function(dataset, use_cache = FALSE, quiet = TRUE) {
   # TODO: Validate dataset?
   cache_file <- cache_path(dataset, "_vectors.rda")
   if (!use_cache || !file.exists(cache_file)) {

--- a/man/list_census_vectors.Rd
+++ b/man/list_census_vectors.Rd
@@ -4,7 +4,7 @@
 \alias{list_census_vectors}
 \title{Query the CensusMapper API for available vectors for a given dataset.}
 \usage{
-list_census_vectors(dataset, use_cache = FALSE, quiet = FALSE)
+list_census_vectors(dataset, use_cache = FALSE, quiet = TRUE)
 }
 \arguments{
 \item{dataset}{The dataset to query for available vectors, e.g.
@@ -14,7 +14,7 @@ list_census_vectors(dataset, use_cache = FALSE, quiet = FALSE)
 available. If set to FALSE (the default), query the API for the data, and
 refresh the local cache with the result.}
 
-\item{quiet}{When TRUE, suppress messages and warnings.}
+\item{quiet}{When FALSE, showss messages and warnings. Set to TRUE by default.}
 }
 \description{
 Query the CensusMapper API for available vectors for a given dataset.


### PR DESCRIPTION
This switches the default parameter to `QUIET` for list_census_vectors. This also affects downstream functions that also use list_census_vectors like search_census_vectors. In practice, I found that it produces too many messages and isn't that useful. 