### PR TITLE
Sf require fix

### DIFF
--- a/R/cancensus.R
+++ b/R/cancensus.R
@@ -165,8 +165,7 @@ get_census <- function (dataset, level, regions, vectors=c(), geo_format = NA, l
     }
     geos <- if (geo_format == "sf") {
       sf::read_sf(geo_file) %>%
-        transform_geo(level) %>%
-        sf::st_as_sf()
+        transform_geo(level)
     } else { # geo_format == "sp"
       geos <- tryCatch({
         rgdal::readOGR(geo_file,geo_base_name)

--- a/R/cancensus.R
+++ b/R/cancensus.R
@@ -182,14 +182,14 @@ get_census <- function (dataset, level, regions, vectors=c(), geo_format = NA, l
       # the sf object needs to be first in join to retain all spatial information
       dplyr::select(result, -.data$Population, -.data$Dwellings,
                     -.data$Households, -.data$Type) %>%
-        dplyr::inner_join(geos, ., by = "GeoUID") %>%
-        sf::st_as_sf()
+        dplyr::inner_join(geos, ., by = "GeoUID")
     } else { # geo_format == "sp"
       geos@data <- dplyr::select(geos@data, -.data$Population, -.data$Dwellings,
                                  -.data$Households, -.data$Type)
       sp::merge(geos, result, by = "GeoUID")
     }
   }
+
 
   if (length(vectors)>0) {
    census_vectors <- names(result)[grep("^v_", names(result))]
@@ -202,6 +202,11 @@ get_census <- function (dataset, level, regions, vectors=c(), geo_format = NA, l
      else {names(result) <- gsub(":.*","",names(result))}
    }
   }
+
+  if (!is.na(geo_format) & geo_format=='sf') { # ensure sf format even if library not loaded
+    result <- sf::st_as_sf(result)
+  }
+
   return(result)
 }
 

--- a/R/cancensus.R
+++ b/R/cancensus.R
@@ -182,7 +182,8 @@ get_census <- function (dataset, level, regions, vectors=c(), geo_format = NA, l
       # the sf object needs to be first in join to retain all spatial information
       dplyr::select(result, -.data$Population, -.data$Dwellings,
                     -.data$Households, -.data$Type) %>%
-        dplyr::inner_join(geos, ., by = "GeoUID")
+        dplyr::inner_join(geos, ., by = "GeoUID") %>%
+        sf::st_as_sf()
     } else { # geo_format == "sp"
       geos@data <- dplyr::select(geos@data, -.data$Population, -.data$Dwellings,
                                  -.data$Households, -.data$Type)

--- a/R/cancensus.R
+++ b/R/cancensus.R
@@ -165,7 +165,8 @@ get_census <- function (dataset, level, regions, vectors=c(), geo_format = NA, l
     }
     geos <- if (geo_format == "sf") {
       sf::read_sf(geo_file) %>%
-        transform_geo(level)
+        transform_geo(level) %>%
+        sf::st_as_sf()
     } else { # geo_format == "sp"
       geos <- tryCatch({
         rgdal::readOGR(geo_file,geo_base_name)
@@ -726,7 +727,7 @@ transform_geo <- function(g, level) {
                      dplyr::funs(as.factor))
 
   #change names
-  #standar table
+  #standard table
   name_change <- dplyr::data_frame(
     old=c("id","a" ,"t" ,"dw","hh","pop","pop2","nrr","q"),
     new=c("GeoUID","Shape Area" ,"Type" ,"Dwellings","Households","Population","Adjusted Population (previous Census)","NHS Non-Return Rate","Quality Flags")
@@ -773,7 +774,6 @@ transform_geo <- function(g, level) {
     old_names[old_names==x]<-name_change$new[name_change$old==x]
   }
   names(g)<-old_names
-  #g <- g %>% rename('GeoUID'='id','Population'='pop','Dwellings'='dw','Households'='hh',"Type"='t')
 
   return(g)
 }


### PR DESCRIPTION
Ensures that `sf` format results have class sf, so long as `sf` is available even if it is not loaded. 