### PR TITLE
Fix bug when requesting multiple variable types at once

### DIFF
--- a/R/vector_discovery.R
+++ b/R/vector_discovery.R
@@ -120,9 +120,9 @@ find_census_vectors <- function(query, dataset, type = "all", query_type = "exac
   census_vector_list <- list_census_vectors(dataset)[, c("vector", "type", "label","details")]
   census_vector_list$details <- gsub("^(.*)Census; |100% data; ","",census_vector_list$details)
   # filter by type if provided
-  if (type %in% c("Total", "Male", "Female"))
+  if (any(type %in% c("Total", "Male", "Female")))
   {
-    census_vector_list <- census_vector_list[census_vector_list$type == type, ]
+    census_vector_list <- census_vector_list[census_vector_list$type %in% type, ]
   }
   if (query_type == "exact") {
     result <- census_vector_list[grep(query, census_vector_list$details, ignore.case = TRUE), ]


### PR DESCRIPTION
Fixes bugs in `find_census_vectors()` flagged in #150. 

```
find_census_vectors("full year, full time", "CA16",
                    type = c("male", "female"),
                    query_type = "exact")
# A tibble: 2 x 4
  vector     type   label              details                                                           
  <chr>      <fct>  <chr>              <chr>                                                             
1 v_CA16_56… Male   Worked full year,… 25% Data; Work; Work Activity; Total population aged 15 years and…
2 v_CA16_56… Female Worked full year,… 25% Data; Work; Work Activity; Total population aged 15 years and…
```

```
find_census_vectors("part year and/or part time", 
                    "CA16",
                    type = c("male", "female"),
                    query_type = "exact")
# A tibble: 2 x 4
  vector    type   label                  details                                                        
  <chr>     <fct>  <chr>                  <chr>                                                          
1 v_CA16_5… Male   Worked part year and/… 25% Data; Work; Work Activity; Total population aged 15 years …
2 v_CA16_5… Female Worked part year and/… 25% Data; Work; Work Activity; Total population aged 15 years …
```

```
find_census_vectors("part year and/or part time", 
                    "CA16",
                    type = "male",
                    query_type = "exact")
# A tibble: 1 x 4
  vector    type  label                  details                                                         
  <chr>     <fct> <chr>                  <chr>                                                           
1 v_CA16_5… Male  Worked part year and/… 25% Data; Work; Work Activity; Total population aged 15 years a…
```