### PR TITLE
Fix a bug with the persistent cache

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -18,8 +18,9 @@ robust_api_key <- function(api_key){
 
 # Append arguments to the path of the local cache directory.
 cache_path <- function(...) {
-  cache_dir <- Sys.getenv("CM_CACHE_PATH")
-  if (nchar(cache_dir)==0 & !is.null(getOption("cancensus.cache_path"))) {
+  if (Sys.getenv("CM_CACHE_PATH") != "") {
+    cache_dir <- Sys.getenv("CM_CACHE_PATH")
+  } else if (nchar(cache_dir)==0 & !is.null(getOption("cancensus.cache_path"))) {
     cache_dir <- getOption("cancensus.cache_path")
   } else cache_dir <- tempdir()
   if (!is.character(cache_dir)) {


### PR DESCRIPTION
Thanks for this wonderful package!

I was having trouble getting the persistent cache to work (in the sense of having it write to the desired location). Upon closer inspection, I believe that the cache gets set to a tempdir in situations where `CM_CACHE_PATH` is set but where the `cancensus.cache_path` option is missing.

Perhaps I missed a step somewhere and managed to have my `CM_CACHE_PATH` set without having the option set as well. In any event, after making a small change to `cache_path()` it seems to work for me.

Raf